### PR TITLE
Get files recursive

### DIFF
--- a/src/System/Directory/Recursive.hs
+++ b/src/System/Directory/Recursive.hs
@@ -1,5 +1,6 @@
 module System.Directory.Recursive ( getDirRecursive
                                   , getSubdirsRecursive
+                                  , getFilesRecursive
                                   , getDirFiltered
                                   ) where
 
@@ -7,7 +8,7 @@ import           Control.Applicative (pure, (<$>))
 import           Control.Monad       (filterM)
 import           Data.Foldable       (fold)
 import           Data.Traversable    (traverse)
-import           System.Directory    (doesDirectoryExist, listDirectory)
+import           System.Directory    (doesDirectoryExist, doesFileExist, listDirectory)
 import           System.FilePath     ((</>))
 import           System.IO.Unsafe    (unsafeInterleaveIO)
 
@@ -18,6 +19,9 @@ getSubdirsRecursive = getDirFiltered doesDirectoryExist
 
 getDirRecursive :: FilePath -> IO [FilePath]
 getDirRecursive = getDirFiltered (const $ pure True)
+
+getFilesRecursive :: FilePath -> IO [FilePath]
+getFilesRecursive fp = getDirRecursive fp >>= filterM doesFileExist
 
 {-# INLINE getDirFiltered #-}
 -- | @since 0.2.2.0

--- a/src/System/Directory/Recursive.hs
+++ b/src/System/Directory/Recursive.hs
@@ -13,18 +13,29 @@ import           System.FilePath     ((</>))
 import           System.IO.Unsafe    (unsafeInterleaveIO)
 
 
--- | @since 0.2.1.0
+-- | Recursively get all subdirectories in the given directory.
+--
+-- @since 0.2.1.0
 getSubdirsRecursive :: FilePath -> IO [FilePath]
 getSubdirsRecursive = getDirFiltered doesDirectoryExist
 
+-- | Recursively get all files and subdirectories in the given directory.
 getDirRecursive :: FilePath -> IO [FilePath]
 getDirRecursive = getDirFiltered (const $ pure True)
 
+-- | Recursively get all files in the given directory.
+--
+-- @since TODO
 getFilesRecursive :: FilePath -> IO [FilePath]
 getFilesRecursive fp = getDirRecursive fp >>= filterM doesFileExist
 
 {-# INLINE getDirFiltered #-}
--- | @since 0.2.2.0
+-- | Recursively get all files and subdirectories in the given directory that
+-- satisfy the given predicate. Note that the content of subdirectories not
+-- matching the filter is ignored. In particular, that means something like
+-- @getDirFiltered doesFileExist@ will /not/ recursively return all files.
+--
+-- @since 0.2.2.0
 getDirFiltered :: (FilePath -> IO Bool) -- ^ Filepath filter
                -> FilePath
                -> IO [FilePath]


### PR DESCRIPTION
Hi,

Thanks for this nice little library! One thing that I missed though was recursively getting all files in a directory. My first guess was `getDirFiltered doesFileExist` but that didn't work because all subdirectories of the given directory were filtered away before the recursion could even start. :smile:

So if you don't mind, this PR adds a `getFilesRecursive` function. (I went with a straightforward implementation but could also offer another variant based on the `getDirFiltered` code if you prefer that.)

I also added a little documentation.

Cheers,
Martin